### PR TITLE
Add arch-test

### DIFF
--- a/build-arm-debian-qemu-image.sh
+++ b/build-arm-debian-qemu-image.sh
@@ -15,6 +15,8 @@ MIRROR=
 INITUDEVPKG=systemd-sysv,udev # or sysvinit-core,udev
 KEYRINGPKG=debian-archive-keyring
 
+apt-get update
+apt-get upgrade -y
 apt-get -q -y --no-install-recommends install arch-test binfmt-support qemu-user-static qemu-efi-arm qemu-efi-aarch64 mmdebstrap qemu-system-arm ipxe-qemu qemu-system-ppc qemu-system-data
 
 MOUNTPT=/tmp/mnt$$

--- a/build-arm-debian-qemu-image.sh
+++ b/build-arm-debian-qemu-image.sh
@@ -15,7 +15,7 @@ MIRROR=
 INITUDEVPKG=systemd-sysv,udev # or sysvinit-core,udev
 KEYRINGPKG=debian-archive-keyring
 
-apt-get -q -y --no-install-recommends install binfmt-support qemu-user-static qemu-efi-arm qemu-efi-aarch64 mmdebstrap qemu-system-arm ipxe-qemu qemu-system-ppc qemu-system-data
+apt-get -q -y --no-install-recommends install arch-test binfmt-support qemu-user-static qemu-efi-arm qemu-efi-aarch64 mmdebstrap qemu-system-arm ipxe-qemu qemu-system-ppc qemu-system-data
 
 MOUNTPT=/tmp/mnt$$
 LOOPDEV=`losetup -f`


### PR DESCRIPTION
`build-arm-debian-qemu-image.sh`を実行すると`arch-test`がないよ！！
と怒られるのを修正